### PR TITLE
passing metadata in case of action_start method implemented into action

### DIFF
--- a/rasa/core/actions/action.py
+++ b/rasa/core/actions/action.py
@@ -566,14 +566,17 @@ class RemoteAction(Action):
         from rasa.shared.core.trackers import EventVerbosity
 
         tracker_state = tracker.current_state(EventVerbosity.ALL)
-
-        return {
+        value = {
             "next_action": self._name,
             "sender_id": tracker.sender_id,
             "tracker": tracker_state,
             "domain": domain.as_dict(),
             "version": rasa.__version__,
         }
+
+        if self._name == ACTION_SESSION_START_NAME and hasattr(self, "metadata"):
+            value["metadata"] = self.__getattribute__("metadata")
+        return value
 
     @staticmethod
     def action_response_format_spec() -> Dict[Text, Any]:


### PR DESCRIPTION
Pass metadata value in case of `action_start` when overwrite in action server 

**Proposed changes**:
- Pass metadata value if present into actions object in case of using remote actions
- Fixed issue

**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
